### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,17 +4,17 @@
 # Class
 #######################################
 
-GuitarixLooper KEYWORD1
+GuitarixLooper	KEYWORD1
 
 #######################################
 # Methods and Functions 
 ####################################### 
 
-recordStart         KEYWORD2
-recordStop          KEYWORD2
-play                KEYWORD2
-pause               KEYWORD2
-erase               KEYWORD2
+recordStart	KEYWORD2
+recordStop	KEYWORD2
+play	KEYWORD2
+pause	KEYWORD2
+erase	KEYWORD2
 
 #######################################
 # Constants
@@ -28,17 +28,17 @@ erase               KEYWORD2
 # Class
 #######################################
 
-GuitarixSingleButtonLooper KEYWORD1
+GuitarixSingleButtonLooper	KEYWORD1
 
 #######################################
 # Methods and Functions 
 ####################################### 
 
-recordBaseLayer     KEYWORD2
-stopRecordBaseLayer KEYWORD2
-addLayer            KEYWORD2
-removeLayer         KEYWORD2
-reset               KEYWORD2
+recordBaseLayer	KEYWORD2
+stopRecordBaseLayer	KEYWORD2
+addLayer	KEYWORD2
+removeLayer	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Constants


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords